### PR TITLE
Fix permission level for auto slowmode

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -53,7 +53,7 @@ export default async (client: CustomClient, message: Message): Promise<void> => 
   Auto Slow will go here
   */
   const autoSlowManager = await client.getAutoSlow(message.channelId);
-  if (autoSlowManager !== null && level < 0 && message.channel instanceof TextChannel) {
+  if (autoSlowManager !== null && level < 1 && message.channel instanceof TextChannel) {
     autoSlowManager.messageSent();
     autoSlowManager.setOptimalSlowMode(message.channel);
   }


### PR DESCRIPTION
For some reason, the previous permission level for members seem to have been below 0 so the old code functioned, this PR only ignores messages from people with a permission level above 0. (This was done to avoid preventing moderators and helpers from affecting slowmode since they are not bound by it.)