### PR TITLE
Fix chain detection

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -150,7 +150,7 @@ export default async (client: CustomClient, message: Message): Promise<void> => 
           }
         }
       } else {
-        if (chMessages.length == CHAIN_DETECTION_LENGTH) chMessages.pop();
+        if (chMessages.length == CHAIN_DETECTION_LENGTH) chMessages.shift();
         chMessages.push({ word: trimMsg(message.content), count: 0 });
         client.channelMessages.set(message.channel.id, chMessages);
       }


### PR DESCRIPTION
This is a simple fix to the chain detection system.
Previous system popped (remove from last) old words and pushed (add to last)  newer ones which resulted in the first "CHAIN_DETECTION_LENGTH - 1" many chained words to always stay in the list. This is fixed by shifting (removing first) instead of popping.