### PR TITLE
Configurable Automatic Reactions 

### DIFF
--- a/src/interactions/chatInput/autopoll.ts
+++ b/src/interactions/chatInput/autopoll.ts
@@ -1,0 +1,132 @@
+import {
+  ApplicationCommandOptionType,
+  CacheType,
+  ChatInputCommandInteraction,
+  CommandInteraction,
+  PermissionsBitField,
+} from "discord.js";
+import {
+  CustomInteractionReplyOptions,
+  InteractionCommand,
+} from "../../classes/CustomInteraction";
+
+import { ApplicationCommandType } from "discord-api-types/v10";
+import { CustomClient } from "lib/client";
+
+const add = "add";
+const remove = "remove";
+const channel = "channel";
+const role = "role";
+
+export default class SlashCommand extends InteractionCommand {
+  /**
+   *
+   */
+  constructor(client: CustomClient) {
+    super(client, {
+      type: ApplicationCommandType.ChatInput,
+      name: "autopoll",
+      description: "Set up automatic polls",
+      options: [
+        {
+          description: "Add a channel",
+          name: add + channel,
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              description: "Channel",
+              name: channel,
+              type: ApplicationCommandOptionType.Channel,
+              required: true,
+            },
+          ],
+        },
+        {
+          description: "Add a role",
+          name: add + role,
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              description: "Role",
+              name: role,
+              type: ApplicationCommandOptionType.Role,
+              required: true,
+            },
+          ],
+        },
+        {
+          description: "Remove a channel",
+          name: remove + channel,
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              description: "Channel",
+              name: channel,
+              type: ApplicationCommandOptionType.Channel,
+              required: true,
+            },
+          ],
+        },
+        {
+          description: "Remove a role",
+          name: remove + role,
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              description: "Role",
+              name: role,
+              type: ApplicationCommandOptionType.Role,
+              required: true,
+            },
+          ],
+        },
+      ],
+      defaultMemberPermissions: new PermissionsBitField("Administrator"),
+    });
+  }
+
+  async execute(
+    interaction: CommandInteraction<CacheType>
+  ): Promise<CustomInteractionReplyOptions> {
+    if (!(interaction instanceof ChatInputCommandInteraction)) {
+      return { content: "Internal Error", eph: true };
+    }
+    const subcommand = interaction.options.getSubcommand();
+    const guildId = interaction.guildId;
+    let channelId;
+    let roleId;
+    switch (subcommand) {
+      case add + channel:
+        channelId = interaction.options.get(channel, true)?.value;
+        if (typeof channelId !== "string") {
+          return { content: "Internal Error (Type mismatch)", eph: true };
+        }
+        await this.client.addAutoPollChannel(guildId, channelId);
+        break;
+      case remove + channel:
+        channelId = interaction.options.get(channel, true)?.value;
+        if (typeof channelId !== "string") {
+          return { content: "Internal Error (Type mismatch)", eph: true };
+        }
+        await this.client.removeAutoPollChannel(guildId, channelId);
+        break;
+      case add + role:
+        roleId = interaction.options.get(role, true)?.value;
+        if (typeof roleId !== "string") {
+          return { content: "Internal Error (Type mismatch)", eph: true };
+        }
+        await this.client.addClosePollRole(guildId, roleId);
+        break;
+      case remove + role:
+        roleId = interaction.options.get(role, true)?.value;
+        if (typeof roleId !== "string") {
+          return { content: "Internal Error (Type mismatch)", eph: true };
+        }
+        await this.client.removeClosePollRole(guildId, roleId);
+        break;
+      default:
+        return { content: "Internal Error (Command not recognized)", eph: true };
+    }
+    return { content: "Successfully updated Autopoll", eph: true };
+  }
+}

--- a/src/lib/reacthandler.ts
+++ b/src/lib/reacthandler.ts
@@ -1,18 +1,62 @@
 import { GuildEmoji, Message, MessageReaction, ReactionEmoji, User } from "discord.js";
 
 import { CustomClient } from "./client";
+import { message } from "gelf-pro";
+
+class AutoPollCache {
+  channels: Map<string, string[]>;
+  roles: Map<string, string[]>;
+
+  constructor() {
+    this.channels = new Map();
+    this.roles = new Map();
+  }
+
+  addChannel(guildId: string, channel: string) {
+    const channels = this.channels.get(guildId) ?? [];
+    channels.push(channel);
+    this.channels.set(guildId, channels);
+  }
+
+  setChannels(guildId: string, channels: string[]) {
+    this.channels.set(guildId, channels);
+  }
+
+  removeChannel(guildId: string, channel: string) {
+    const channels = this.channels.get(guildId) ?? [];
+    channels.filter((v) => v != channel);
+    this.roles.set(guildId, channels);
+  }
+
+  getChannels(guildId: string): string[] | undefined {
+    return this.channels.get(guildId);
+  }
+
+  addRole(guildId: string, role: string) {
+    const roles = this.roles.get(guildId) ?? [];
+    roles.push(role);
+    this.roles.set(guildId, roles);
+  }
+
+  setRoles(guildId: string, roles: string[]) {
+    this.roles.set(guildId, roles);
+  }
+
+  removeRole(guildId: string, role: string) {
+    const roles = this.roles.get(guildId) ?? [];
+    roles.filter((v) => v != role);
+    this.roles.set(guildId, roles);
+  }
+
+  getRoles(guildId: string): string[] | undefined {
+    return this.roles.get(guildId);
+  }
+}
+
+export const autoPollCache = new AutoPollCache();
 
 export class ReactionHandler {
   client: CustomClient;
-  closePollsRoles = ["707248297290629120", "580770272521617446", "502973976428150784"];
-  autoReactChannels = [
-    "664579652261773333",
-    "601476169312763904",
-    "843762959607791676",
-    "675650786838970368",
-    "907004131456221235",
-    "849283795484147763",
-  ];
   autoReactions = ["👍", "👎", "❌"];
   /**
    *
@@ -22,7 +66,13 @@ export class ReactionHandler {
   }
 
   async onNewMessage(message: Message): Promise<void> {
-    if (this.autoReactChannels.indexOf(message.channelId) < 0) return;
+    const autoReactChannels = await this.client.getAutoPollChannels(
+      message.guildId ?? ""
+    );
+    if (autoReactChannels === undefined) {
+      return;
+    }
+    if (autoReactChannels.indexOf(message.channelId) < 0) return;
     // Just add the autoreactions
     for (const reaction of this.autoReactions) {
       const success = await message.react(reaction).catch(() => {});
@@ -36,15 +86,18 @@ export class ReactionHandler {
     const member = await reaction.message.guild?.members.fetch(user.id).catch(() => {});
     if (!member) return;
 
-    if (
-      this.autoReactions.indexOf(reaction.emoji.name as string) == 2 &&
-      member.roles.cache.hasAny(...this.closePollsRoles)
-    ) {
-      const shouldRemove = reaction.message.reactions.cache.size > 1;
-      if (!shouldRemove) return;
-      const removed = await reaction.message.reactions.removeAll().catch(() => {});
-      if (removed) await reaction.message.react(this.autoReactions[2]);
+    if (this.autoReactions.indexOf(reaction.emoji.name as string) != 2) {
+      return;
     }
+    let roles = await this.client.getClosePollRoles(reaction.message.guildId ?? "");
+    roles = roles ?? [];
+    if (!member.roles.cache.hasAny(...roles)) {
+      return;
+    }
+    const shouldRemove = reaction.message.reactions.cache.size > 1;
+    if (!shouldRemove) return;
+    const removed = await reaction.message.reactions.removeAll().catch(() => {});
+    if (removed) await reaction.message.react(this.autoReactions[2]);
   }
 
   private isReactionEmoji(emoji: ReactionEmoji | GuildEmoji): emoji is ReactionEmoji {

--- a/src/models/AutoPoll.ts
+++ b/src/models/AutoPoll.ts
@@ -1,0 +1,17 @@
+import { Model, Schema, model } from "mongoose";
+
+import { IAutoPoll } from "types/mongodb";
+
+const AutoPollSchema = new Schema({
+  guildId: String,
+  channels: {
+    type: [String],
+    default: [],
+  },
+  roles: {
+    type: [String],
+    default: [],
+  },
+});
+
+export const AutoPollModel: Model<IAutoPoll> = model("AutoPoll", AutoPollSchema);

--- a/src/types/discordjs.d.ts
+++ b/src/types/discordjs.d.ts
@@ -51,6 +51,18 @@ declare module "discord.js" {
 
     getAutoSlow(channelId: string): Promise<AutoSlowManager | null>;
 
+    addAutoPollChannel(guildId: string, channelId: string): Promise<void>;
+
+    removeAutoPollChannel(guildId: string, channelId: string): Promise<void>;
+
+    addClosePollRole(guildId: string, roleId: string): Promise<void>;
+
+    removeClosePollRole(guildId: string, roleId: string): Promise<void>;
+
+    getAutoPollChannels(guildId: string): Promise<string[] | undefined>;
+
+    getClosePollRoles(guildId: string): Promise<string[] | undefined>;
+
     setEmojiSuggestions(emojiSuggestions: EmojiSuggestions): Promise<void>;
 
     getEmojiSuggestions(guildId: string): Promise<EmojiSuggestions | null>;

--- a/src/types/mongodb.ts
+++ b/src/types/mongodb.ts
@@ -94,3 +94,11 @@ interface RawCommandCooldown {
 }
 
 export interface ICommandCooldown extends RawCommandCooldown, Document {}
+
+interface RawAutoPoll {
+  guildId: string;
+  channels: string[];
+  roles: string[];
+}
+
+export interface IAutoPoll extends RawAutoPoll, Document {}


### PR DESCRIPTION
Previously, the auto poll channels and close poll roles were hard coded. This PR makes it so it's done via commands and is saved to the database.

Poll closing seems to have broken at one point. That will be fixed with another PR.