### PR TITLE
Make slow mode adjust more slowly

### DIFF
--- a/src/interactions/chatInput/autoslow.ts
+++ b/src/interactions/chatInput/autoslow.ts
@@ -19,7 +19,7 @@ import { CustomClient } from "lib/client";
 const MIN = "min";
 const MAX = "max";
 const FREQUENCY = "frequency";
-const MIN_CHANGE = "minchange";
+const MAX_CHANGE = "maxchange";
 const RATE_OF_CHANGE = "rateofchange";
 const ENABLED = "enabled";
 
@@ -58,15 +58,15 @@ export default class SlashCommand extends InteractionCommand {
               type: ApplicationCommandOptionType.Number,
             },
             {
-              name: MIN_CHANGE,
+              name: MAX_CHANGE,
               description:
-                "Minimum amount slow mode is allowed to change by (suggested: 5)",
+                "The default maximum amount slowmode is allowed to change by. (suggested: 5)",
               type: ApplicationCommandOptionType.Number,
             },
             {
               name: RATE_OF_CHANGE,
               description:
-                "Maximum rate of change allowed for slow mode at higher values (suggested: 2)",
+                "The amount slowmode is allowed to change, proportional to current slow mode. This overrides the default if higher. (suggested: 2)",
               type: ApplicationCommandOptionType.Number,
             },
             {
@@ -130,7 +130,7 @@ export default class SlashCommand extends InteractionCommand {
     const commandMin = interaction.options.get(MIN)?.value;
     const commandMax = interaction.options.get(MAX)?.value;
     const commandFreq = interaction.options.get(FREQUENCY)?.value;
-    const commandMinChange = interaction.options.get(MIN_CHANGE)?.value;
+    const commandMinChange = interaction.options.get(MAX_CHANGE)?.value;
     const commandRateOfChange = interaction.options.get(RATE_OF_CHANGE)?.value;
     const commandEnabled = interaction.options.get(ENABLED)?.value;
 

--- a/src/interactions/chatInput/autoslow.ts
+++ b/src/interactions/chatInput/autoslow.ts
@@ -1,8 +1,10 @@
 import {
+  APIEmbedField,
   ApplicationCommandOptionType,
   CacheType,
   ChatInputCommandInteraction,
   CommandInteraction,
+  EmbedBuilder,
   PermissionsBitField,
 } from "discord.js";
 import {
@@ -11,11 +13,14 @@ import {
 } from "../../classes/CustomInteraction";
 
 import { ApplicationCommandType } from "discord-api-types/v10";
+import { AutoSlowManager } from "lib/autoslow";
 import { CustomClient } from "lib/client";
 
 const MIN = "min";
 const MAX = "max";
 const FREQUENCY = "frequency";
+const MIN_CHANGE = "minchange";
+const RATE_OF_CHANGE = "rateofchange";
 const ENABLED = "enabled";
 
 const CONFIG = "config";
@@ -53,6 +58,18 @@ export default class SlashCommand extends InteractionCommand {
               type: ApplicationCommandOptionType.Number,
             },
             {
+              name: MIN_CHANGE,
+              description:
+                "Minimum amount slow mode is allowed to change by (suggested: 5)",
+              type: ApplicationCommandOptionType.Number,
+            },
+            {
+              name: RATE_OF_CHANGE,
+              description:
+                "Maximum rate of change allowed for slow mode at higher values (suggested: 2)",
+              type: ApplicationCommandOptionType.Number,
+            },
+            {
               name: ENABLED,
               description: "Autoslow enabled/disabled",
               type: ApplicationCommandOptionType.Boolean,
@@ -73,6 +90,23 @@ export default class SlashCommand extends InteractionCommand {
       ],
       defaultMemberPermissions: new PermissionsBitField("Administrator"),
     });
+  }
+
+  paramEmbed(autoSlow: AutoSlowManager): APIEmbedField[] {
+    const min = Math.floor(autoSlow.minSlow);
+    const max = Math.floor(autoSlow.maxSlow);
+    const freq = autoSlow.targetMsgsPerSec.toFixed(2);
+    const minChange = autoSlow.minAbsoluteChange.toFixed(2);
+    const rateOfChange = (autoSlow.minChangeRate * 100).toFixed(0);
+    const enabled = autoSlow.enabled ? "enabled" : "disabled";
+    return [
+      { name: "min", value: `${min}s` },
+      { name: "max", value: `${max}s` },
+      { name: "freq", value: `${freq} msg/s` },
+      { name: "min change", value: `${minChange}s` },
+      { name: "min rate of change", value: `${rateOfChange}%` },
+      { name: "state", value: enabled },
+    ];
   }
 
   async execute(
@@ -96,19 +130,20 @@ export default class SlashCommand extends InteractionCommand {
     const commandMin = interaction.options.get(MIN)?.value;
     const commandMax = interaction.options.get(MAX)?.value;
     const commandFreq = interaction.options.get(FREQUENCY)?.value;
+    const commandMinChange = interaction.options.get(MIN_CHANGE)?.value;
+    const commandRateOfChange = interaction.options.get(RATE_OF_CHANGE)?.value;
     const commandEnabled = interaction.options.get(ENABLED)?.value;
 
     if (subCommand === GET) {
-      let content = "Autoslow doesn't exist in this channel";
+      let title = "Autoslow doesn't exist in this channel";
+      let params: APIEmbedField[] = [];
       if (currentAutoSlow !== null) {
-        content = `Current autoslow parameters:
-        min: ${currentAutoSlow.minSlow}s
-        max: ${currentAutoSlow.maxSlow}s
-        freq: ${currentAutoSlow.targetMsgsPerSec} msg/s
-        enabled: ${currentAutoSlow.enabled}`;
+        title = "Autoslow parameters";
+        params = this.paramEmbed(currentAutoSlow);
       }
+      const embed = new EmbedBuilder().setTitle(title).addFields(params);
       return {
-        content: content,
+        embeds: [embed],
         eph: true,
       };
     }
@@ -116,12 +151,16 @@ export default class SlashCommand extends InteractionCommand {
     const min = commandMin ?? currentAutoSlow?.minSlow;
     const max = commandMax ?? currentAutoSlow?.maxSlow;
     const freq = commandFreq ?? currentAutoSlow?.targetMsgsPerSec;
+    const minChange = commandMinChange ?? currentAutoSlow?.minAbsoluteChange;
+    const minChangeRate = commandRateOfChange ?? currentAutoSlow?.minChangeRate;
     const enabled = commandEnabled ?? currentAutoSlow?.enabled;
 
     if (
       typeof min !== "number" ||
       typeof max !== "number" ||
       typeof freq !== "number" ||
+      typeof minChange !== "number" ||
+      typeof minChangeRate !== "number" ||
       typeof enabled !== "boolean"
     ) {
       return { content: "Missing parameters", eph: true };
@@ -140,14 +179,40 @@ export default class SlashCommand extends InteractionCommand {
         eph: true,
       };
     }
+    if (minChange < 0) {
+      return {
+        content: "Error: Minimum Change cannot be negative",
+        eph: true,
+      };
+    }
+    if (minChangeRate < 0) {
+      return {
+        content: "Error: Minimum Change Rate cannot be negative",
+        eph: true,
+      };
+    }
+    if (minChange < 0.5 && min * minChangeRate < 0.5) {
+      return {
+        content: "Error: Minimum Change and Change Rate is too small",
+        eph: true,
+      };
+    }
 
-    this.client.addAutoSlow(interaction.channelId, min, max, freq, enabled);
+    const autoSlow = await this.client.addAutoSlow(
+      interaction.channelId,
+      min,
+      max,
+      freq,
+      minChange,
+      minChangeRate,
+      enabled
+    );
+    const params = this.paramEmbed(autoSlow);
+    const embed = new EmbedBuilder()
+      .setTitle("Success: Setup slow mode")
+      .addFields(params);
     return {
-      content: `Success: Setup slow mode
-       min: ${min}s
-       max: ${max}s
-       freq: ${freq}
-       enabled: ${enabled}`,
+      embeds: [embed],
       eph: true,
     };
   }

--- a/src/lib/autoslow.ts
+++ b/src/lib/autoslow.ts
@@ -2,13 +2,12 @@ import { TextChannel } from "discord.js";
 
 const BASE = 0.95;
 
-const minChangeRate = 0.75;
-const minAbsoluteChange = 5;
-
 export class AutoSlowManager {
   minSlow: number;
   maxSlow: number;
   targetMsgsPerSec: number;
+  minChangeRate: number;
+  minAbsoluteChange: number;
   enabled: boolean;
 
   msgBalance: number;
@@ -21,11 +20,15 @@ export class AutoSlowManager {
     minSlow: number,
     maxSlow: number,
     targetMsgsPerSec: number,
+    minChangeRate: number,
+    minAbsoluteChange: number,
     enabled: boolean
   ) {
     this.minSlow = minSlow;
     this.maxSlow = maxSlow;
     this.targetMsgsPerSec = targetMsgsPerSec;
+    this.minChangeRate = minChangeRate;
+    this.minAbsoluteChange = minAbsoluteChange;
     this.enabled = enabled;
     this.msgBalance = 0;
     this.lastTime = null;
@@ -81,7 +84,7 @@ export class AutoSlowManager {
       return slowMode;
     } else {
       const optimal = (Math.max(slowMode, 1) * currentBalance) / targetBalance;
-      const maxChange = Math.max(minAbsoluteChange, slowMode * minChangeRate);
+      const maxChange = Math.max(this.minAbsoluteChange, slowMode * this.minChangeRate);
       const min = Math.max(this.minSlow, slowMode - maxChange);
       const max = Math.min(this.maxSlow, slowMode + maxChange);
       return Math.min(Math.max(optimal, min), max);

--- a/src/lib/autoslow.ts
+++ b/src/lib/autoslow.ts
@@ -81,7 +81,7 @@ export class AutoSlowManager {
       return slowMode;
     } else {
       const optimal = (Math.max(slowMode, 1) * currentBalance) / targetBalance;
-      const maxChange = Math.max(minAbsoluteChange, Math.abs(slowMode * minChangeRate));
+      const maxChange = Math.max(minAbsoluteChange, slowMode * minChangeRate);
       const min = Math.max(this.minSlow, slowMode - maxChange);
       const max = Math.min(this.maxSlow, slowMode + maxChange);
       return Math.min(Math.max(optimal, min), max);

--- a/src/lib/autoslow.ts
+++ b/src/lib/autoslow.ts
@@ -90,7 +90,7 @@ export class AutoSlowManager {
       );
       const downwardsChange = Math.max(
         this.minAbsoluteChange,
-        slowMode / (1 + this.minChangeRate)
+        slowMode / this.minChangeRate
       );
 
       const min = Math.max(this.minSlow, slowMode - downwardsChange);

--- a/src/lib/autoslow.ts
+++ b/src/lib/autoslow.ts
@@ -84,9 +84,17 @@ export class AutoSlowManager {
       return slowMode;
     } else {
       const optimal = (Math.max(slowMode, 1) * currentBalance) / targetBalance;
-      const maxChange = Math.max(this.minAbsoluteChange, slowMode * this.minChangeRate);
-      const min = Math.max(this.minSlow, slowMode - maxChange);
-      const max = Math.min(this.maxSlow, slowMode + maxChange);
+      const upwardsChange = Math.max(
+        this.minAbsoluteChange,
+        slowMode * this.minChangeRate
+      );
+      const downwardsChange = Math.max(
+        this.minAbsoluteChange,
+        slowMode / (1 + this.minChangeRate)
+      );
+
+      const min = Math.max(this.minSlow, slowMode - downwardsChange);
+      const max = Math.min(this.maxSlow, slowMode + upwardsChange);
       return Math.min(Math.max(optimal, min), max);
     }
   }

--- a/src/lib/autoslow.ts
+++ b/src/lib/autoslow.ts
@@ -2,6 +2,9 @@ import { TextChannel } from "discord.js";
 
 const BASE = 0.95;
 
+const minChangeRate = 0.75;
+const minAbsoluteChange = 5;
+
 export class AutoSlowManager {
   minSlow: number;
   maxSlow: number;
@@ -78,7 +81,10 @@ export class AutoSlowManager {
       return slowMode;
     } else {
       const optimal = (Math.max(slowMode, 1) * currentBalance) / targetBalance;
-      return Math.min(Math.max(optimal, this.minSlow), this.maxSlow);
+      const maxChange = Math.max(minAbsoluteChange, Math.abs(slowMode * minChangeRate));
+      const min = Math.max(this.minSlow, slowMode - maxChange);
+      const max = Math.min(this.maxSlow, slowMode + maxChange);
+      return Math.min(Math.max(optimal, min), max);
     }
   }
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -263,9 +263,18 @@ export class CustomClient extends Client {
     min: number,
     max: number,
     targetMsgsPerSec: number,
+    minChange: number,
+    minChangeRate: number,
     enabled: boolean
-  ): Promise<void> {
-    const autoSlow = new AutoSlowManager(min, max, targetMsgsPerSec, enabled);
+  ): Promise<AutoSlowManager> {
+    const autoSlow = new AutoSlowManager(
+      min,
+      max,
+      targetMsgsPerSec,
+      minChangeRate,
+      minChange,
+      enabled
+    );
     AutoSlowCache.addAutoSlow(channelId, autoSlow);
     await AutoSlowModel.findOneAndUpdate(
       {
@@ -275,6 +284,8 @@ export class CustomClient extends Client {
         min: min,
         max: max,
         targetMsgsPerSec: targetMsgsPerSec,
+        minChange: minChange,
+        minChangeRate: minChangeRate,
         enabled: enabled,
       },
       {
@@ -283,6 +294,7 @@ export class CustomClient extends Client {
         setDefaultsOnInsert: true,
       }
     );
+    return autoSlow;
   }
 
   async removeAutoSlow(channelId: string): Promise<void> {

--- a/src/types/discordjs.d.ts
+++ b/src/types/discordjs.d.ts
@@ -1,6 +1,7 @@
 import { Collection, EmbedBuilder, Message } from "discord.js";
 import { IAutoSlow, ISettings } from "./mongodb";
 
+import { AutoSlowManager } from "lib/autoslow";
 import { Command } from "./command";
 import { Config } from "config";
 import { EmojiSuggestions } from "lib/emojiSuggestions";
@@ -44,8 +45,10 @@ declare module "discord.js" {
       min: number,
       max: number,
       targetMsgsPerSec: number,
+      minChange: number,
+      minChangeRate: number,
       enabled: boolean
-    ): Promise<void>;
+    ): Promise<AutoSlowManager>;
 
     removeAutoSlow(channelId: string): Promise<void>;
 

--- a/src/types/mongodb.ts
+++ b/src/types/mongodb.ts
@@ -68,6 +68,8 @@ interface RawAutoSlow {
   targetMsgsPerSec: number;
   min: number;
   max: number;
+  minChange: number;
+  minChangeRate: number;
   enabled: boolean;
 }
 


### PR DESCRIPTION
Auto slow used to change too quickly in cases where chat activity had a small spike. This PR makes it adapt more slowly by limiting the amount slow mode can change depending on current slow mode in a configurable way.