### PR TITLE
Block emoji suggestions if set emoji cap has already been hit

### DIFF
--- a/src/interactions/chatInput/emojiSuggest.ts
+++ b/src/interactions/chatInput/emojiSuggest.ts
@@ -84,7 +84,12 @@ export default class SlashCommand extends InteractionCommand {
         eph: true,
       };
     }
-
+    if (interaction.guild.emojis.cache.size >= emojiSuggestionsConfig.emojiCap) {
+      return {
+        content: "Emoji cap has been hit, wait for updates",
+        eph: true,
+      };
+    }
     const lastUse = await this.client.getLastCommandUse(
       interaction.guildId,
       commandId,


### PR DESCRIPTION
The suggest emoji command returns an ephemeral telling the user that the emoji cap has been hit when appropriate in order to prevent more emojis from being submitted.