### PR TITLE
Automatic Ping setup command

### DIFF
--- a/src/events/threadCreate.ts
+++ b/src/events/threadCreate.ts
@@ -1,0 +1,7 @@
+import { CustomClient } from "lib/client";
+import { GuildChannel } from "discord.js";
+import { threadCreated as forumPostCreated } from "lib/autoping";
+
+export default async (client: CustomClient, thread: GuildChannel): Promise<void> => {
+  forumPostCreated(client, thread);
+};

--- a/src/interactions/chatInput/autoping.ts
+++ b/src/interactions/chatInput/autoping.ts
@@ -1,0 +1,175 @@
+import {
+  ApplicationCommandOptionType,
+  CacheType,
+  ChatInputCommandInteraction,
+  CommandInteraction,
+  EmbedBuilder,
+  PermissionsBitField,
+} from "discord.js";
+import {
+  CustomInteractionReplyOptions,
+  InteractionCommand,
+} from "../../classes/CustomInteraction";
+
+import { ApplicationCommandType } from "discord-api-types/v10";
+import { CustomClient } from "lib/client";
+
+const register = "register";
+const remove = "remove";
+const list = "list";
+const clear = "clear";
+
+const role = "role";
+const forum = "forum";
+const tag = "tag";
+const ping = "ping";
+
+export const allTag = "all";
+
+export default class SlashCommand extends InteractionCommand {
+  /**
+   *
+   */
+  constructor(client: CustomClient) {
+    super(client, {
+      type: ApplicationCommandType.ChatInput,
+      name: "autoping",
+      description: "Set up automatic pings!",
+      options: [
+        {
+          description: "register a role to automatically notify",
+          name: register,
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              description: "Role to ping",
+              name: role,
+              type: ApplicationCommandOptionType.Role,
+              required: true,
+            },
+            {
+              description: "Channel/Forum that pings the role",
+              name: forum,
+              type: ApplicationCommandOptionType.Channel,
+              required: true,
+            },
+            {
+              description: "Channel to ping the role in",
+              name: ping,
+              type: ApplicationCommandOptionType.Channel,
+              required: true,
+            },
+            {
+              description: `Forum tag to trigger pings, write ${allTag} to be pinged for everything`,
+              name: tag,
+              type: ApplicationCommandOptionType.String,
+              required: true,
+            },
+          ],
+        },
+        {
+          description: "Clear all automatic pings",
+          name: clear,
+          type: ApplicationCommandOptionType.Subcommand,
+        },
+        {
+          description: "List all automatic pings",
+          name: list,
+          type: ApplicationCommandOptionType.Subcommand,
+        },
+        {
+          description:
+            "Remove every autoping that matches, leave field empty to match all",
+          name: remove,
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              description: "Role to ping",
+              name: role,
+              type: ApplicationCommandOptionType.Role,
+            },
+            {
+              description: "Channel/Forum that pings the role",
+              name: forum,
+              type: ApplicationCommandOptionType.Channel,
+            },
+            {
+              description: "Channel to ping the role in",
+              name: ping,
+              type: ApplicationCommandOptionType.Channel,
+            },
+            {
+              description: "Forum tag to trigger pings",
+              name: tag,
+              type: ApplicationCommandOptionType.String,
+            },
+          ],
+        },
+      ],
+      defaultMemberPermissions: new PermissionsBitField("Administrator"),
+    });
+  }
+
+  async execute(
+    interaction: CommandInteraction<CacheType>
+  ): Promise<CustomInteractionReplyOptions> {
+    if (!(interaction instanceof ChatInputCommandInteraction)) {
+      return { content: "Internal Error", eph: true };
+    }
+    const guildId = interaction.guildId;
+    const subcommand = interaction.options.getSubcommand();
+    switch (subcommand) {
+      case register:
+        const roleId = interaction.options.getRole(role, true).id;
+        const forumId = interaction.options.getChannel(forum, true).id;
+        const tagName = interaction.options.getString(tag, true);
+        const targetChannelId = interaction.options.getChannel(ping, true);
+        await this.client.addAutoPing(
+          guildId,
+          roleId,
+          forumId,
+          tagName,
+          targetChannelId.id
+        );
+        return {
+          content: "Successfully registered automatic pings",
+          eph: true,
+        };
+      case list:
+        const autoPings = await this.client.getAllAutoPing(guildId);
+        const autoPingMessage = [];
+        let index = 0;
+        const title =
+          autoPings.length === 0
+            ? "No Auto-ping Setup"
+            : `${autoPings.length} Auto-pings`;
+        for (const autoPing of autoPings) {
+          autoPingMessage.push({
+            name: `auto-ping ${index}`,
+            value: `<#${autoPing.forumId}> with tag ${autoPing.tag} pings <@&${autoPing.roleId}> in <#${autoPing.targetChannelId}>\n`,
+          });
+          index += 1;
+        }
+        const embed = new EmbedBuilder().setTitle(title).addFields(autoPingMessage);
+        return {
+          embeds: [embed],
+          eph: true,
+        };
+      case remove:
+        const roleId2 = interaction.options.getRole(role, false)?.id;
+        const forumId2 = interaction.options.getChannel(forum, false)?.id;
+        const tagName2 = interaction.options.getString(tag, false) ?? undefined;
+        const targetChannelId2 = interaction.options.getChannel(ping, false);
+        await this.client.removeAutoPings(
+          guildId,
+          roleId2,
+          forumId2,
+          tagName2,
+          targetChannelId2?.id
+        );
+        return { content: "Removed automatic pings", eph: true };
+    }
+
+    return {};
+  }
+}

--- a/src/lib/autoping.ts
+++ b/src/lib/autoping.ts
@@ -1,0 +1,41 @@
+import { ForumChannel, GuildChannel, TextChannel, ThreadChannel } from "discord.js";
+
+import { CustomClient } from "./client";
+
+export async function threadCreated(client: CustomClient, thread: GuildChannel) {
+  if (thread.parentId === null) {
+    return;
+  }
+  if (!(thread instanceof ThreadChannel)) {
+    return;
+  }
+  const forum = await thread.guild.channels.fetch(thread.parentId);
+  if (!(forum instanceof ForumChannel)) {
+    return;
+  }
+  const appliedTags = forum.availableTags
+    .filter((tag) => thread.appliedTags.includes(tag.id))
+    .map((tag) => tag.name.toLowerCase().match("[a-z0-9_]*")?.join("").trim());
+
+  const autoPings = await client.getAutoPing(thread.guildId, thread.parentId);
+  for (const autoPing of autoPings) {
+    const pingChannel = await client.channels.fetch(autoPing.targetChannelId);
+    if (!(pingChannel instanceof TextChannel)) {
+      continue;
+    }
+    const pingRole = await thread.guild.roles.fetch(autoPing.roleId);
+    if (pingRole === null) {
+      continue;
+    }
+
+    if (
+      autoPing.tag !== "all" &&
+      appliedTags.find((value) => value === autoPing.tag) === undefined
+    ) {
+      continue;
+    }
+    const tag = autoPing.tag.length === 0 ? "" : `with tag ${autoPing.tag}`;
+    const message = `<@&${pingRole.id}> New post <#${thread.id}> under <#${thread.parentId}>  ${tag}`;
+    await pingChannel.send({ content: message });
+  }
+}

--- a/src/models/AutoPing.ts
+++ b/src/models/AutoPing.ts
@@ -1,0 +1,13 @@
+import { Model, Schema, model } from "mongoose";
+
+import { IAutoPing } from "types/mongodb";
+
+const AutoPingSchema = new Schema({
+  guildId: String,
+  roleId: String,
+  forumId: String,
+  tag: String,
+  targetChannelId: String,
+});
+
+export const AutoPingModel: Model<IAutoPing> = model("AutoPing", AutoPingSchema);

--- a/src/types/discordjs.d.ts
+++ b/src/types/discordjs.d.ts
@@ -1,5 +1,5 @@
 import { Collection, EmbedBuilder, Message } from "discord.js";
-import { IAutoSlow, ISettings } from "./mongodb";
+import { IAutoPing, IAutoSlow, ISettings } from "./mongodb";
 
 import { AutoSlowManager } from "lib/autoslow";
 import { Command } from "./command";
@@ -86,6 +86,26 @@ declare module "discord.js" {
       commandId: string,
       userId: string
     ): Promise<number | null>;
+
+    addAutoPing(
+      guildId: string,
+      roleId: string,
+      forumId: string,
+      tag: string,
+      targetChannelId: string
+    ): Promise<void>;
+
+    getAutoPing(guildId: string, forumId: string): Promise<IAutoPing[]>;
+
+    removeAutoPings(
+      guildId: string,
+      roleId: string,
+      forumId: string,
+      tag: string,
+      targetChannelId: string
+    ): Promise<void>;
+
+    getAllAutoPing(guildId: string): Promise<IAutoPing[]>;
   }
 
   export interface Base {

--- a/src/types/mongodb.ts
+++ b/src/types/mongodb.ts
@@ -98,3 +98,14 @@ interface RawCommandCooldown {
 }
 
 export interface ICommandCooldown extends RawCommandCooldown, Document {}
+
+/* AUTOPING */
+interface RawAutoPing {
+  guildId: string;
+  roleId: string;
+  forumId: string;
+  tag: string;
+  targetChannelId: string;
+}
+
+export interface IAutoPing extends RawAutoPing, Document {}


### PR DESCRIPTION
Set up automatic pings.

This command supports:

1. Pinging a role in a specific channel whenever a forum post is made under a certain category.
The tags that trigger a ping are also parametrized.

2. List all current automatic pings

3. Remove automatic pings that match a given pattern (This is the same behavior as MongoDB)  