### PR TITLE
Keep popularity statistics on emojis

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -11,6 +11,7 @@ import { Command } from "types/command";
 import { CustomClient } from "../lib/client";
 import { ICommand } from "types/mongodb";
 import { SettingsModel } from "../models/Settings";
+import { countEmoji } from "lib/stats";
 
 const chainStops = ["muck"];
 const CHAIN_STOPS_ONLY = false; // Only triggers on chainStops
@@ -60,6 +61,7 @@ export default async (client: CustomClient, message: Message): Promise<void> => 
     autoSlowManager.messageSent();
     autoSlowManager.setOptimalSlowMode(message.channel);
   }
+  await countEmoji(client, message);
 
   // Do whatever message filtering here
   if (level == -1) {

--- a/src/interactions/chatInput/listEmoji.ts
+++ b/src/interactions/chatInput/listEmoji.ts
@@ -1,0 +1,72 @@
+import {
+  CacheType,
+  ChatInputCommandInteraction,
+  CommandInteraction,
+  EmbedBuilder,
+  PermissionsBitField,
+} from "discord.js";
+import {
+  CustomInteractionReplyOptions,
+  InteractionCommand,
+} from "../../classes/CustomInteraction";
+
+import { ApplicationCommandType } from "discord-api-types/v10";
+import { CustomClient } from "lib/client";
+
+export default class SlashCommand extends InteractionCommand {
+  /**
+   *
+   */
+  constructor(client: CustomClient) {
+    super(client, {
+      type: ApplicationCommandType.ChatInput,
+      name: "listemoji",
+      description: "Rank community emojis by popularity",
+      defaultMemberPermissions: new PermissionsBitField("Administrator"),
+    });
+  }
+
+  async execute(
+    interaction: CommandInteraction<CacheType>
+  ): Promise<CustomInteractionReplyOptions> {
+    if (!(interaction instanceof ChatInputCommandInteraction)) {
+      return { content: "Internal Error", eph: true };
+    }
+    const emojis = await this.client.listEmoji(interaction.guildId);
+
+    const embedFields = [];
+
+    emojis.sort((a, b) => b.count - a.count);
+
+    const total = emojis.map((emoji) => emoji.count).reduce((x, y) => x + y, 0);
+    if (total === 0) {
+      return { content: "Internal Error", eph: true };
+    }
+    const avg = total / emojis.length;
+    let index = 1;
+    for (const emoji of emojis) {
+      let percentPopularity = ((emoji.count - avg) / avg) * 100;
+
+      let message = "more popular than average";
+      if (percentPopularity < 0) {
+        percentPopularity = -percentPopularity;
+        message = "less popular than average";
+      }
+      if (percentPopularity < 1) {
+        message = "is average";
+      }
+
+      if (percentPopularity)
+        embedFields.push({
+          name: `#${index} ${emoji.name}`,
+          value: `${percentPopularity.toFixed(1)}% ${message}`,
+        });
+      index++;
+    }
+    const embed = new EmbedBuilder()
+      .setTitle("Most used community emojis")
+      .setFields(embedFields);
+
+    return { embeds: [embed], eph: true };
+  }
+}

--- a/src/interactions/chatInput/listEmoji.ts
+++ b/src/interactions/chatInput/listEmoji.ts
@@ -47,19 +47,19 @@ export default class SlashCommand extends InteractionCommand {
     for (const emoji of emojis) {
       let percentPopularity = ((emoji.count - avg) / avg) * 100;
 
-      let message = "more popular than average";
+      let message = `${percentPopularity.toFixed(1)} more popular than average`;
       if (percentPopularity < 0) {
         percentPopularity = -percentPopularity;
-        message = "less popular than average";
+        message = `${percentPopularity.toFixed(1)}% less popular than average`;
       }
       if (percentPopularity < 1) {
-        message = "is average";
+        message = `Is average`;
       }
 
       if (percentPopularity)
         embedFields.push({
           name: `#${index} ${emoji.name}`,
-          value: `${percentPopularity.toFixed(1)}% ${message}`,
+          value: message,
         });
       index++;
     }

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,35 @@
+import { CustomClient } from "./client";
+import { Message } from "discord.js";
+import { emojiSuffix } from "interactions/chatInput/emojiSuggest";
+
+const regex = new RegExp(`:[a-zA-Z1-9_]+${emojiSuffix}:`);
+
+export class EmojiUsage {
+  name: string;
+  count: number;
+
+  constructor(name: string, count: number) {
+    this.name = name;
+    this.count = count;
+  }
+}
+
+export async function countEmoji(client: CustomClient, message: Message): Promise<void> {
+  if (message.guildId === null) {
+    return;
+  }
+  const matches = message.content.match(regex);
+  if (matches === null) {
+    return;
+  }
+
+  for (const match of matches) {
+    const emojiName = match.substring(1, match.length - 1);
+    if (
+      message.guild?.emojis.cache.find((value) => value.name === emojiName) === undefined
+    ) {
+      continue;
+    }
+    await client.addEmoji(message.guildId, emojiName);
+  }
+}

--- a/src/models/EmojiUsage.ts
+++ b/src/models/EmojiUsage.ts
@@ -1,0 +1,15 @@
+import { Model, Schema, model } from "mongoose";
+
+import { IEmojiUsage } from "types/mongodb";
+
+const EmojiUsageSchema = new Schema({
+  guildId: String,
+  name: String,
+  count: {
+    type: Number,
+    default: 1,
+  },
+  lastUsage: Number,
+});
+
+export const EmojiUsageModel: Model<IEmojiUsage> = model("EmojiUsage", EmojiUsageSchema);

--- a/src/types/discordjs.d.ts
+++ b/src/types/discordjs.d.ts
@@ -1,5 +1,5 @@
 import { Collection, EmbedBuilder, Message } from "discord.js";
-import { IAutoPing, IAutoSlow, ISettings } from "./mongodb";
+import { IAutoPing, IAutoSlow, IEmojiUsage, ISettings } from "./mongodb";
 
 import { AutoSlowManager } from "lib/autoslow";
 import { Command } from "./command";
@@ -106,6 +106,10 @@ declare module "discord.js" {
     ): Promise<void>;
 
     getAllAutoPing(guildId: string): Promise<IAutoPing[]>;
+
+    addEmoji(guildId: string, name: string): Promise<void>;
+
+    listEmoji(guildId: string): Promise<EmojiUsage[]>;
   }
 
   export interface Base {

--- a/src/types/mongodb.ts
+++ b/src/types/mongodb.ts
@@ -109,3 +109,12 @@ interface RawAutoPing {
 }
 
 export interface IAutoPing extends RawAutoPing, Document {}
+
+interface RawEmojiUsage {
+  guildId: string;
+  name: string;
+  count: number;
+  lastUsage: number;
+}
+
+export interface IEmojiUsage extends RawEmojiUsage, Document {}


### PR DESCRIPTION
Keeps track of the relative popularity of all community emojis. 
An emoji can be counted as "used" every 15 minutes and the amount an emoji used drops by 10% every day in order to take recency into account.
These statistics can later be used to remove community emojis that aren't used.