### PR TITLE
trigger ignore  + cleaned up stuff + fixed color

### DIFF
--- a/src/interactions/chatInput/trigger.ts
+++ b/src/interactions/chatInput/trigger.ts
@@ -114,6 +114,12 @@ export default class SlashCommand extends InteractionCommand {
               type: ApplicationCommandOptionType.String,
               required: true,
             },
+            {
+              name: "clear",
+              description: "If set to true, deletes opt outs.",
+              type: ApplicationCommandOptionType.Boolean,
+              required: true,
+            },
           ],
         },
         {
@@ -265,6 +271,7 @@ export default class SlashCommand extends InteractionCommand {
       });
     } else if (subcommand == "remove") {
       const id = interaction.options.getString("id", true);
+      const clear = interaction.options.getBoolean("clear", true);
 
       if (interaction.settings.triggers.some((t) => t.id == id)) {
         this.client.settings.set(
@@ -276,10 +283,12 @@ export default class SlashCommand extends InteractionCommand {
           )
         );
 
-        await TriggerModel.deleteMany({
-          guildId: interaction.guild.id,
-          triggerId: `trigger-${id}`,
-        });
+        if (clear) {
+          await TriggerModel.deleteMany({
+            guildId: interaction.guild.id,
+            triggerId: `trigger-${id}`,
+          });
+        }
 
         await interaction.reply({
           embeds: [

--- a/src/interactions/chatInput/trigger.ts
+++ b/src/interactions/chatInput/trigger.ts
@@ -15,6 +15,7 @@ import { ApplicationCommandType } from "discord-api-types/v10";
 import { CustomClient } from "lib/client";
 import { SettingsModel } from "models/Settings";
 import { TriggerModel } from "models/Trigger";
+import { isColor } from "lib/utils";
 
 export default class SlashCommand extends InteractionCommand {
   constructor(client: CustomClient) {
@@ -242,7 +243,7 @@ export default class SlashCommand extends InteractionCommand {
           content: content || "",
           title: title || "",
           description: description || "",
-          color: color || "Random",
+          color: isColor(color) ? color : "Red",
         },
       };
 

--- a/src/interactions/chatInput/trigger.ts
+++ b/src/interactions/chatInput/trigger.ts
@@ -1,10 +1,10 @@
-import { 
-    ApplicationCommandOptionType,
-    CacheType,
-    ChatInputCommandInteraction,
-    CommandInteraction,
-    EmbedBuilder,
-    PermissionsBitField
+import {
+  ApplicationCommandOptionType,
+  CacheType,
+  ChatInputCommandInteraction,
+  CommandInteraction,
+  EmbedBuilder,
+  PermissionsBitField,
 } from "discord.js";
 import {
   CustomInteractionReplyOptions,
@@ -25,136 +25,160 @@ export default class SlashCommand extends InteractionCommand {
       defaultMemberPermissions: new PermissionsBitField("Administrator"),
       options: [
         {
-            name: "add",
-            description: "Add a trigger.",
-            type: ApplicationCommandOptionType.Subcommand,
-            options: [
-                {
-                    name: "id",
-                    description: "The id of the trigger",
-                    type: ApplicationCommandOptionType.String,
-                    required: true,
-                },
-                {
-                    name: "cooldown",
-                    description: "The cooldown of the trigger",
-                    type: ApplicationCommandOptionType.Number,
-                    required: true,
-                },
-                {
-                    name: "content",
-                    description: "The content of the reply message.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                },
-                {
-                    name: "title",
-                    description: "The title of the reply message's embed.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                },
-                {
-                    name: "description",
-                    description: "The description of the reply message's embed.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                },
-                {
-                    name: "color",
-                    description: "The color of the reply message's embed.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                },
-                {
-                    name: "keywords1",
-                    description: "The first group of keywords of the trigger, separated by ','.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                },
-                {
-                    name: "keywords2",
-                    description: "The second group of keywords of the trigger, separated by ','.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                },
-                {
-                    name: "keywords3",
-                    description: "The third group of keywords of the trigger, separated by ','.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                },
-                {
-                    name: "keywords4",
-                    description: "The fourth group of keywords of the trigger, separated by ','.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                },
-                {
-                    name: "keywords5",
-                    description: "The fifth group of keywords of the trigger, separated by ','.",
-                    type: ApplicationCommandOptionType.String,
-                    required: false,
-                }, //so ugly
-            ]
+          name: "add",
+          description: "Add a trigger.",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "id",
+              description: "The id of the trigger",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+            },
+            {
+              name: "cooldown",
+              description: "The cooldown of the trigger",
+              type: ApplicationCommandOptionType.Number,
+              required: true,
+            },
+            {
+              name: "content",
+              description: "The content of the reply message.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            },
+            {
+              name: "title",
+              description: "The title of the reply message's embed.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            },
+            {
+              name: "description",
+              description: "The description of the reply message's embed.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            },
+            {
+              name: "color",
+              description: "The color of the reply message's embed.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            },
+            {
+              name: "keywords1",
+              description:
+                "The first group of keywords of the trigger, separated by ','.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            },
+            {
+              name: "keywords2",
+              description:
+                "The second group of keywords of the trigger, separated by ','.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            },
+            {
+              name: "keywords3",
+              description:
+                "The third group of keywords of the trigger, separated by ','.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            },
+            {
+              name: "keywords4",
+              description:
+                "The fourth group of keywords of the trigger, separated by ','.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            },
+            {
+              name: "keywords5",
+              description:
+                "The fifth group of keywords of the trigger, separated by ','.",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+            }, //so ugly
+          ],
         },
         {
-            name: "remove",
-            description: "Remove a trigger.",
-            type: ApplicationCommandOptionType.Subcommand,
-            options: [
-                {
-                    name: "id",
-                    description: "The id of the trigger.",
-                    type: ApplicationCommandOptionType.String,
-                    required: true,
-                }
-            ]
+          name: "remove",
+          description: "Remove a trigger.",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "id",
+              description: "The id of the trigger.",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+            },
+          ],
         },
         {
-            name: "enable",
-            description: "Enable a trigger.",
-            type: ApplicationCommandOptionType.Subcommand,
-            options: [
-                {
-                    name: "id",
-                    description: "The id of the trigger.",
-                    type: ApplicationCommandOptionType.String,
-                    required: true,
-                }
-            ]
+          name: "enable",
+          description: "Enable a trigger.",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "id",
+              description: "The id of the trigger.",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+            },
+          ],
         },
         {
-            name: "disable",
-            description: "Disable a trigger.",
-            type: ApplicationCommandOptionType.Subcommand,
-            options: [
-                {
-                    name: "id",
-                    description: "The id of the trigger.",
-                    type: ApplicationCommandOptionType.String,
-                    required: true,
-                }
-            ]
+          name: "disable",
+          description: "Disable a trigger.",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "id",
+              description: "The id of the trigger.",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+            },
+          ],
         },
         {
-            name: "get",
-            description: "Get information about a trigger.",
-            type: ApplicationCommandOptionType.Subcommand,
-            options: [
-                {
-                    name: "id",
-                    description: "The id of the trigger.",
-                    type: ApplicationCommandOptionType.String,
-                    required: true,
-                }
-            ]
+          name: "get",
+          description: "Get information about a trigger.",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "id",
+              description: "The id of the trigger.",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+            },
+          ],
         },
         {
-            name: "list",
-            description: "Get a list of triggers for this guild.",
-            type: ApplicationCommandOptionType.Subcommand,
-        }
-      ]
+          name: "ignore",
+          description: "Opts out a user from a trigger",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "user",
+              description: "The user to opt out.",
+              type: ApplicationCommandOptionType.User,
+              required: true,
+            },
+            {
+              name: "id",
+              description: "The id of the trigger.",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+            },
+          ],
+        },
+        {
+          name: "list",
+          description: "Get a list of triggers for this guild.",
+          type: ApplicationCommandOptionType.Subcommand,
+        },
+      ],
     });
   }
 
@@ -162,243 +186,269 @@ export default class SlashCommand extends InteractionCommand {
     interaction: CommandInteraction<CacheType>
   ): Promise<CustomInteractionReplyOptions> {
     if (!(interaction instanceof ChatInputCommandInteraction)) {
-        return { content: "Internal Error", eph: true };
+      return { content: "Internal Error", eph: true };
     }
 
     const subcommand = interaction.options.getSubcommand();
+    const permLevel = this.client.permlevel(undefined, interaction.member);
+
+    const adminOnly = ["add", "remove", "enable", "disable", "get"];
+    const staffOnly = ["ignore", "list"];
+
+    if (permLevel < 4 && adminOnly.includes(subcommand)) {
+      return { content: "Insufficient Permissions", eph: true };
+    }
+
+    if (permLevel < 2 && staffOnly.includes(subcommand)) {
+      return { content: "Insufficient Permissions", eph: true };
+    }
 
     if (subcommand == "add") {
-        const id = interaction.options.getString("id", true);
-        const exists = interaction.settings.triggers.some(t => t.id == id);
+      const id = interaction.options.getString("id", true);
+      const exists = interaction.settings.triggers.some((t) => t.id == id);
 
-        if (exists) {
-            await interaction.reply({
-                embeds: [
-                  this.client.errEmb(
-                    2,
-                    `Trigger \`${id}\` already exists.`
-                  ),
-                ]
-            });
+      if (exists) {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Trigger \`${id}\` already exists`)],
+        });
 
-            return {};
+        return {};
+      }
+
+      const cooldown = interaction.options.getNumber("cooldown", true);
+      const content = interaction.options.getString("content", false);
+      const title = interaction.options.getString("title", false);
+      const description = interaction.options.getString("description", false);
+      const color = interaction.options.getString("color", false);
+      const embed = title != null || description != null || color != null;
+
+      let keywords: string[][] = [];
+
+      for (let i = 1; i <= 5; i++) {
+        const group = interaction.options.getString(`keywords${i}`, false);
+
+        if (group) {
+          keywords.push(group.split(",").map((s) => s.trim()));
         }
+      }
 
-        const cooldown = interaction.options.getNumber("cooldown", true);
-        const content = interaction.options.getString("content", false);
-        const title = interaction.options.getString("title", false);
-        const description = interaction.options.getString("description", false);
-        const color = interaction.options.getString("color", false);
-        const embed = title != null || description != null || color != null;
+      const trigger = {
+        id: id,
+        keywords: keywords,
+        cooldown: cooldown,
+        enabled: true,
+        message: {
+          embed: embed,
+          content: content || "",
+          title: title || "",
+          description: description || "",
+          color: color || "Random",
+        },
+      };
 
-        let keywords: string[][] = [];
+      this.client.settings.set(
+        interaction.settings._id,
+        await SettingsModel.findOneAndUpdate(
+          { _id: interaction.settings._id },
+          { $push: { triggers: trigger }, toUpdate: true },
+          { upsert: true, setDefaultsOnInsert: true, new: true }
+        )
+      );
 
-        for (let i = 1; i <= 5; i++) {
-            const group = interaction.options.getString(`keywords${i}`, false);
+      await interaction.reply({
+        embeds: [
+          new EmbedBuilder()
+            .setDescription(`Added new trigger \`${id}\``)
+            .setColor("Green"),
+        ],
+      });
+    } else if (subcommand == "remove") {
+      const id = interaction.options.getString("id", true);
 
-            if (group) {
-                keywords.push(group.split(',').map(s => s.trim()));
-            }
-        }
+      if (interaction.settings.triggers.some((t) => t.id == id)) {
+        this.client.settings.set(
+          interaction.settings._id,
+          await SettingsModel.findOneAndUpdate(
+            { _id: interaction.settings._id },
+            { $pull: { triggers: { id: id } }, toUpdate: true },
+            { upsert: true, setDefaultsOnInsert: true, new: true }
+          )
+        );
 
-        const trigger = {
-            id: id,
-            keywords: keywords,
-            cooldown: cooldown,
-            enabled: true,
-            message: {
-                embed: embed,
-                content: content || "",
-                title: title || "",
-                description: description || "",
-                color: color || "Random",
-            }
-        };
+        await TriggerModel.deleteMany({
+          guildId: interaction.guild.id,
+          triggerId: `trigger-${id}`,
+        });
+
+        await interaction.reply({
+          embeds: [
+            new EmbedBuilder()
+              .setDescription(`Removed trigger \`${id}\``)
+              .setColor("Green"),
+          ],
+        });
+      } else {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Trigger \`${id}\` already does not exist`)],
+        });
+      }
+    } else if (subcommand == "enable") {
+      const id = interaction.options.getString("id", true);
+      const trigger = interaction.settings.triggers.find((t) => t.id == id);
+
+      if (trigger && !trigger.enabled) {
+        const newTriggers = interaction.settings.triggers.map((t) => {
+          if (t.id != id) {
+            return t;
+          } else {
+            t.enabled = true;
+            return t;
+          }
+        });
 
         this.client.settings.set(
-            interaction.settings._id,
-            await SettingsModel.findOneAndUpdate(
-              { _id: interaction.settings._id },
-              { $push: { triggers: trigger }, toUpdate: true },
-              { upsert: true, setDefaultsOnInsert: true, new: true }
-            )
+          interaction.settings._id,
+          await SettingsModel.findOneAndUpdate(
+            { _id: interaction.settings._id },
+            { triggers: newTriggers, toUpdate: true },
+            { upsert: true, setDefaultsOnInsert: true, new: true }
+          )
         );
 
         await interaction.reply({
-            embeds: [
-                new EmbedBuilder()
-                    .setDescription(`Added new trigger \`${id}\`.`)
-                    .setColor("Green")
-            ]
+          embeds: [
+            new EmbedBuilder()
+              .setDescription(`Enabled trigger \`${id}\``)
+              .setColor("Green"),
+          ],
         });
-    } else if (subcommand == "remove") {
-        const id = interaction.options.getString("id", true);
-        const newTriggers = interaction.settings.triggers.filter(t => t.id != id);
-
-        if (newTriggers.length < interaction.settings.triggers.length) {
-            this.client.settings.set(
-                interaction.settings._id,
-                await SettingsModel.findOneAndUpdate(
-                  { _id: interaction.settings._id },
-                  { triggers: newTriggers, toUpdate: true },
-                  { upsert: true, setDefaultsOnInsert: true, new: true }
-                )
-            );
-
-            await TriggerModel.deleteMany({ guildId: interaction.guild.id, triggerId: `trigger-${id}`});
-
-            await interaction.reply({
-                embeds: [
-                    new EmbedBuilder()
-                        .setDescription(`Removed trigger \`${id}\`.`)
-                        .setColor("Green")
-                ]
-            });
-        } else {
-            await interaction.reply({
-                embeds: [
-                  this.client.errEmb(
-                    2,
-                    `Trigger \`${id}\` already does not exist.`
-                  ),
-                ]
-            });
-        }
-    } else if (subcommand == "enable") {
-        const id = interaction.options.getString("id", true);
-        const trigger = interaction.settings.triggers.find(t => t.id == id);
-
-        if (trigger && !trigger.enabled) {
-            const newTriggers = interaction.settings.triggers.map(t => {
-                if (t.id != id) {
-                    return t;
-                } else {
-                    t.enabled = true;
-                    return t;
-                }
-            });
-
-            this.client.settings.set(
-                interaction.settings._id,
-                await SettingsModel.findOneAndUpdate(
-                  { _id: interaction.settings._id },
-                  { triggers: newTriggers, toUpdate: true },
-                  { upsert: true, setDefaultsOnInsert: true, new: true }
-                )
-            );
-
-            await interaction.reply({
-                embeds: [
-                    new EmbedBuilder()
-                        .setDescription(`Enabled trigger \`${id}\`.`)
-                        .setColor("Green")
-                ]
-            });
-        } else if (trigger) {
-            await interaction.reply({
-                embeds: [
-                  this.client.errEmb(
-                    2,
-                    `Trigger \`${id}\` already enabled.`
-                  ),
-                ]
-            });
-        } else {
-            await interaction.reply({
-                embeds: [
-                  this.client.errEmb(
-                    2,
-                    `Trigger \`${id}\` does not exist.`
-                  ),
-                ]
-            });
-        }
+      } else if (trigger) {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Trigger \`${id}\` already enabled`)],
+        });
+      } else {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Trigger \`${id}\` does not exist`)],
+        });
+      }
     } else if (subcommand == "disable") {
-        const id = interaction.options.getString("id", true);
-        const trigger = interaction.settings.triggers.find(t => t.id == id);
+      const id = interaction.options.getString("id", true);
+      const trigger = interaction.settings.triggers.find((t) => t.id == id);
 
-        if (trigger && trigger.enabled) {
-            const newTriggers = interaction.settings.triggers.map(t => {
-                if (t.id != id) {
-                    return t;
-                } else {
-                    t.enabled = false;
-                    return t;
-                }
-            });
-            
-            this.client.settings.set(
-                interaction.settings._id,
-                await SettingsModel.findOneAndUpdate(
-                  { _id: interaction.settings._id },
-                  { triggers: newTriggers, toUpdate: true },
-                  { upsert: true, setDefaultsOnInsert: true, new: true }
-                )
-            );
+      if (trigger && trigger.enabled) {
+        const newTriggers = interaction.settings.triggers.map((t) => {
+          if (t.id != id) {
+            return t;
+          } else {
+            t.enabled = false;
+            return t;
+          }
+        });
 
-            await interaction.reply({
-                embeds: [
-                    new EmbedBuilder()
-                        .setDescription(`Disabled trigger \`${id}\`.`)
-                        .setColor("Green")
-                ]
-            });
-        } else if (trigger) {
-            await interaction.reply({
-                embeds: [
-                  this.client.errEmb(
-                    2,
-                    `Trigger \`${id}\` already disabled.`
-                  ),
-                ]
-            });
-        } else {
-            await interaction.reply({
-                embeds: [
-                  this.client.errEmb(
-                    2,
-                    `Trigger \`${id}\` does not exist.`
-                  ),
-                ]
-            });
-        }
-    } else if (subcommand == "get") {
-        const id = interaction.options.getString("id", true);
-        const trigger = interaction.settings.triggers.find(t => t.id == id);
-
-        if (trigger) {
-            const keywords = trigger.keywords.map(g => `[${g.map(s => `\`${s}\``).join(', ')}]`).join(', ');
-            
-            await interaction.reply({
-              embeds: [
-                new EmbedBuilder()
-                  .setColor("Green")
-                  .setDescription(`**ID**: ${trigger.id}\n**Cooldown**: ${trigger.cooldown}\n**Enabled**: ${trigger.enabled}\n**Keywords**: ${keywords}`)
-              ]
-            });
-        } else {
-            await interaction.reply({
-              embeds: [
-                this.client.errEmb(
-                  2,
-                  `Trigger \`${id}\` does not exist.`
-                ),
-              ]
-            });
-        }
-    } else if (subcommand == "list") {
-        const triggers = interaction.settings.triggers;
-        const str = triggers.length == 0 ? "No triggers in guild" : triggers.map(t => `\`${t.id}\``).join(', ');
+        this.client.settings.set(
+          interaction.settings._id,
+          await SettingsModel.findOneAndUpdate(
+            { _id: interaction.settings._id },
+            { triggers: newTriggers, toUpdate: true },
+            { upsert: true, setDefaultsOnInsert: true, new: true }
+          )
+        );
 
         await interaction.reply({
-            embeds: [
-              new EmbedBuilder()
-                .setColor("Green")
-                .setDescription(str)
-            ]
+          embeds: [
+            new EmbedBuilder()
+              .setDescription(`Disabled trigger \`${id}\``)
+              .setColor("Green"),
+          ],
         });
+      } else if (trigger) {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Trigger \`${id}\` already disabled`)],
+        });
+      } else {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Trigger \`${id}\` does not exist`)],
+        });
+      }
+    } else if (subcommand == "get") {
+      const id = interaction.options.getString("id", true);
+      const trigger = interaction.settings.triggers.find((t) => t.id == id);
+
+      if (trigger) {
+        const keywords = trigger.keywords
+          .map((g) => `[${g.map((s) => `\`${s}\``).join(", ")}]`)
+          .join(", ");
+
+        await interaction.reply({
+          embeds: [
+            new EmbedBuilder()
+              .setColor("Green")
+              .setDescription(
+                `**ID**: ${trigger.id}\n**Cooldown**: ${trigger.cooldown}\n**Enabled**: ${trigger.enabled}\n**Keywords**: ${keywords}`
+              ),
+          ],
+        });
+      } else {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Trigger \`${id}\` does not exist`)],
+        });
+      }
+    } else if (subcommand == "ignore") {
+      const member = interaction.options.getMember("user");
+      const id = interaction.options.getString("id", true);
+      const triggerId = `trigger-${id}`;
+
+      if (!member) {
+        return { content: "User is not a member of this guild", eph: true };
+      }
+
+      if (!interaction.settings.triggers.some((t) => t.id == id)) {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Trigger \`${id}\` does not exist.`)],
+          ephemeral: true,
+        });
+
+        return {};
+      }
+
+      const optedOut = await TriggerModel.exists({
+        guildId: interaction.guild.id,
+        userId: member.id,
+        triggerId: triggerId,
+      });
+
+      if (optedOut) {
+        await interaction.reply({
+          content: "User has already opted out in this guild",
+          ephemeral: true,
+        });
+      } else {
+        await new TriggerModel({
+          guildId: interaction.guild.id,
+          userId: member.id,
+          triggerId: triggerId,
+        }).save();
+
+        await interaction.reply({
+          embeds: [
+            new EmbedBuilder()
+              .setColor("Green")
+              .setDescription(`${member} will not trigger \`${id}\` again`),
+          ],
+        });
+      }
+    } else if (subcommand == "list") {
+      const triggers = interaction.settings.triggers;
+      const str =
+        triggers.length == 0
+          ? "No triggers in guild"
+          : triggers.map((t) => `\`${t.id}\``).join(", ");
+
+      await interaction.reply({
+        embeds: [new EmbedBuilder().setColor("Green").setDescription(str)],
+      });
     }
-    
+
     return {};
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,10 @@ function eliminateUnicode(name: string): string {
 }
 
 export function isColor(value: any): value is ColorResolvable {
+  if (value == null || value == undefined) {
+    return false;
+  }
+
   if (value in Colors) {
     return true;
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { ColorResolvable, Colors } from "discord.js";
+
 export function unicode2Ascii(name: string): string {
   const asciiNameNfkd = name.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
   const finalNameNfkd = eliminateUnicode(asciiNameNfkd);
@@ -15,4 +17,32 @@ function eliminateUnicode(name: string): string {
     }
   }
   return finalName;
+}
+
+export function isColor(value: any): value is ColorResolvable {
+  if (value in Colors) {
+    return true;
+  }
+
+  if (typeof value === "string" && /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(value)) {
+    return true;
+  }
+
+  if (value === "Random") {
+    return true;
+  }
+
+  if (typeof value === "number") {
+    return true;
+  }
+
+  if (
+    Array.isArray(value) &&
+    value.length === 3 &&
+    value.every((num) => typeof num === "number")
+  ) {
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
Added /trigger ignore which allows helpers and above to force users to opt out of the trigger. Also added explicit permission checks to the command, so now only admins and above have access to /trigger add remove enable disable and get, and helpers and above have access to /trigger ignore and list.

Cleaned up some stuff in the relevant code as well like using `await new TriggerModel().save()` instead of `await TriggerModel.updateOne()` and `$pull: {triggers: {id: id } }` instead of replacing it with a new array that doesn't include the one with the id. Some shit also got accidentally changed because apparently VSCode is quite the formatter himself.

As for the color, it didn't check if the color was valid before casting it for the embed, which would probably not be very fun for the bot if you inputted an invalid color in /trigger add and it got triggered. I just made it default to red if the color was invalid.

Resolves #41 . 