### PR TITLE
Auto-delete polls

### DIFF
--- a/src/events/raw.ts
+++ b/src/events/raw.ts
@@ -1,0 +1,60 @@
+import { CustomClient } from "lib/client";
+import { SettingsModel } from "models/Settings";
+
+export default async (client: CustomClient, packet: any): Promise<void> => {
+  const data = packet.d;
+
+  if (!data.poll) {
+    return;
+  }
+
+  const channel = await client.channels.fetch(data.channel_id);
+
+  if (!channel || !channel.isTextBased()) {
+    return;
+  }
+
+  const message = await channel.messages.fetch(data.id);
+
+  if (!message || message.author.bot || !message.guild) {
+    return;
+  }
+
+  /*if (client.permlevel(message, message.member!) >= 2) {
+    return;
+  }*/
+
+  if (!client.settings.has(message.guild.id)) {
+    const s = await SettingsModel.findOneAndUpdate(
+      { _id: message.guild.id },
+      { toUpdate: true },
+      {
+        upsert: true,
+        setDefaultsOnInsert: true,
+        new: true,
+      }
+    )
+      .populate("mentorRoles")
+      .populate("commands");
+
+    log.debug("Setting sync", {
+      action: "Fetch",
+      message: `Database -> Client (${message.guild.id})`,
+    });
+
+    message.settings = s;
+  } else {
+    const s = client.settings.get(message.guild.id);
+
+    if (!s) {
+      return;
+    }
+
+    message.settings = s;
+  }
+
+  if (!message.settings.pollsAllowed.includes(channel.id)) {
+    await message.reply("You are not allowed to send polls in this channel.");
+    await message.delete();
+  }
+};

--- a/src/events/raw.ts
+++ b/src/events/raw.ts
@@ -21,9 +21,9 @@ export default async (client: CustomClient, packet: any): Promise<void> => {
     return;
   }
 
-  /*if (client.permlevel(message, message.member!) >= 2) {
+  if (client.permlevel(message, message.member!) >= 2) {
     return;
-  }*/
+  }
 
   if (!client.settings.has(message.guild.id)) {
     const s = await SettingsModel.findOneAndUpdate(

--- a/src/events/raw.ts
+++ b/src/events/raw.ts
@@ -1,3 +1,4 @@
+import { ChannelType } from "discord.js";
 import { CustomClient } from "lib/client";
 import { SettingsModel } from "models/Settings";
 
@@ -20,9 +21,9 @@ export default async (client: CustomClient, packet: any): Promise<void> => {
     return;
   }
 
-  if (client.permlevel(message, message.member!) >= 2) {
+  /*if (client.permlevel(message, message.member!) >= 2) {
     return;
-  }
+  }*/
 
   if (!client.settings.has(message.guild.id)) {
     const s = await SettingsModel.findOneAndUpdate(
@@ -53,7 +54,10 @@ export default async (client: CustomClient, packet: any): Promise<void> => {
     message.settings = s;
   }
 
-  if (!message.settings.pollsAllowed.includes(channel.id)) {
+  const pollsAllowed = message.settings.pollsAllowed;
+  const isThread = channel.type == ChannelType.PublicThread && channel.parent !== null;
+
+  if (!pollsAllowed.includes(channel.id) && (isThread && !pollsAllowed.includes(channel.parent.id))) {
     await message.reply("You are not allowed to send polls in this channel.");
     await message.delete();
   }

--- a/src/events/raw.ts
+++ b/src/events/raw.ts
@@ -68,6 +68,6 @@ export default async (client: CustomClient, packet: any): Promise<void> => {
 
     setTimeout(async () => {
       await msg.delete();
-    }, 2000);
+    }, 5000);
   }
 };

--- a/src/events/raw.ts
+++ b/src/events/raw.ts
@@ -20,9 +20,9 @@ export default async (client: CustomClient, packet: any): Promise<void> => {
     return;
   }
 
-  /*if (client.permlevel(message, message.member!) >= 2) {
+  if (client.permlevel(message, message.member!) >= 2) {
     return;
-  }*/
+  }
 
   if (!client.settings.has(message.guild.id)) {
     const s = await SettingsModel.findOneAndUpdate(

--- a/src/events/raw.ts
+++ b/src/events/raw.ts
@@ -56,9 +56,18 @@ export default async (client: CustomClient, packet: any): Promise<void> => {
 
   const pollsAllowed = message.settings.pollsAllowed;
   const isThread = channel.type == ChannelType.PublicThread && channel.parent !== null;
+  const channelCondition = !isThread && !pollsAllowed.includes(channel.id);
+  const threadCondition =
+    isThread &&
+    !pollsAllowed.includes(channel.parent.id) &&
+    !pollsAllowed.includes(channel.id);
 
-  if (!pollsAllowed.includes(channel.id) && (isThread && !pollsAllowed.includes(channel.parent.id))) {
-    await message.reply("You are not allowed to send polls in this channel.");
+  if (channelCondition || threadCondition) {
+    const msg = await message.reply("You are not allowed to send polls in this channel.");
     await message.delete();
+
+    setTimeout(async () => {
+      await msg.delete();
+    }, 2000);
   }
 };

--- a/src/interactions/chatInput/polls.ts
+++ b/src/interactions/chatInput/polls.ts
@@ -35,7 +35,9 @@ export default class SlashCommand extends InteractionCommand {
               channelTypes: [
                 ChannelType.GuildText,
                 ChannelType.GuildVoice,
+                ChannelType.GuildForum,
                 ChannelType.GuildAnnouncement,
+                ChannelType.PublicThread,
               ],
             },
           ],
@@ -53,7 +55,9 @@ export default class SlashCommand extends InteractionCommand {
               channelTypes: [
                 ChannelType.GuildText,
                 ChannelType.GuildVoice,
+                ChannelType.GuildForum,
                 ChannelType.GuildAnnouncement,
+                ChannelType.PublicThread,
               ],
             },
           ],
@@ -80,7 +84,9 @@ export default class SlashCommand extends InteractionCommand {
     const channel = interaction.options.getChannel("channel", true, [
       ChannelType.GuildText,
       ChannelType.GuildVoice,
+      ChannelType.GuildForum,
       ChannelType.GuildAnnouncement,
+      ChannelType.PublicThread,
     ]);
 
     if (subcmd == "enable") {

--- a/src/interactions/chatInput/polls.ts
+++ b/src/interactions/chatInput/polls.ts
@@ -1,0 +1,136 @@
+import {
+  ApplicationCommandOptionType,
+  CacheType,
+  ChannelType,
+  ChatInputCommandInteraction,
+  CommandInteraction,
+  EmbedBuilder,
+} from "discord.js";
+import {
+  CustomInteractionReplyOptions,
+  InteractionCommand,
+} from "../../classes/CustomInteraction";
+
+import { ApplicationCommandType } from "discord-api-types/v10";
+import { CustomClient } from "lib/client";
+import { SettingsModel } from "models/Settings";
+
+export default class SlashCommand extends InteractionCommand {
+  constructor(client: CustomClient) {
+    super(client, {
+      type: ApplicationCommandType.ChatInput,
+      name: "polls",
+      description: "Enable/disable polls in channels.",
+      options: [
+        {
+          name: "enable",
+          description: "Enable polls in a channel.",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "channel",
+              description: "The channel.",
+              required: true,
+              type: ApplicationCommandOptionType.Channel,
+              channelTypes: [
+                ChannelType.GuildText,
+                ChannelType.GuildVoice,
+                ChannelType.GuildAnnouncement,
+              ],
+            },
+          ],
+        },
+        {
+          name: "disable",
+          description: "Disable polls in a channel.",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "channel",
+              description: "The channel.",
+              required: true,
+              type: ApplicationCommandOptionType.Channel,
+              channelTypes: [
+                ChannelType.GuildText,
+                ChannelType.GuildVoice,
+                ChannelType.GuildAnnouncement,
+              ],
+            },
+          ],
+        },
+      ],
+      defaultMemberPermissions: "Administrator",
+    });
+  }
+
+  async execute(
+    interaction: CommandInteraction<CacheType>
+  ): Promise<CustomInteractionReplyOptions> {
+    if (!(interaction instanceof ChatInputCommandInteraction)) {
+      return { content: "Internal Error", eph: true };
+    }
+
+    const permLevel = this.client.permlevel(undefined, interaction.member);
+
+    if (permLevel < 4) {
+      return { content: "Insufficient Permissions", eph: true };
+    }
+
+    const subcmd = interaction.options.getSubcommand();
+    const channel = interaction.options.getChannel("channel", true, [
+      ChannelType.GuildText,
+      ChannelType.GuildVoice,
+      ChannelType.GuildAnnouncement,
+    ]);
+
+    if (subcmd == "enable") {
+      if (!interaction.settings.pollsAllowed.includes(channel.id)) {
+        this.client.settings.set(
+          interaction.settings._id,
+          await SettingsModel.findOneAndUpdate(
+            { _id: interaction.settings._id },
+            { $push: { pollsAllowed: channel.id }, toUpdate: true },
+            { upsert: true, setDefaultsOnInsert: true, new: true }
+          )
+        );
+
+        await interaction.reply({
+          embeds: [
+            new EmbedBuilder()
+              .setDescription(`Enabled polls in ${channel}`)
+              .setColor("Green"),
+          ],
+        });
+      } else {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Polls are already enabled in ${channel}`)],
+        });
+      }
+    } else if (subcmd == "disable") {
+      if (interaction.settings.pollsAllowed.includes(channel.id)) {
+        this.client.settings.set(
+          interaction.settings._id,
+          await SettingsModel.findOneAndUpdate(
+            { _id: interaction.settings._id },
+            { $pull: { pollsAllowed: channel.id }, toUpdate: true },
+            { upsert: true, setDefaultsOnInsert: true, new: true }
+          )
+        );
+
+        await interaction.reply({
+          embeds: [
+            new EmbedBuilder()
+              .setDescription(`Disabled polls in ${channel}`)
+              .setColor("Green"),
+          ],
+        });
+      } else {
+        await interaction.reply({
+          embeds: [this.client.errEmb(2, `Polls are already disabled in ${channel}`)],
+        });
+      }
+    }
+
+    return {};
+  }
+}

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -11,6 +11,7 @@ const SettingsSchema = new Schema(
     chains: {
       ignored: [String],
     },
+    pollsAllowed: [String],
     triggers: [{
       id: String,
       keywords: [[String]],

--- a/src/types/mongodb.ts
+++ b/src/types/mongodb.ts
@@ -30,6 +30,7 @@ export interface RawSettings {
   chains: {
     ignored: string[];
   };
+  pollsAllowed: string[];
   triggers: {
     id: string;
     keywords: string[][];


### PR DESCRIPTION
- Made DSU automatically delete messages with polls (through raw event because polls are currently inaccessible through discord.js Message object).
- A command to enable/disable polls in text channels, voice channels, and threads.
- Polls are disabled by default in all channels.
- Threads inherit from their parent channel (text or forum) so polls can't be disabled in the thread if they are enabled in the parent channel, but can be enabled in the thread if they are disabled in the parent channel.
- Everyone with perm level Helper or above is immune and can post polls anywhere as they wish.
- Polls can only be enabled/disabled in a channel by someone with perm level Administrator or above.