### PR TITLE
block them sounds

### DIFF
--- a/src/events/raw.ts
+++ b/src/events/raw.ts
@@ -7,10 +7,13 @@ export default async (client: CustomClient, packet: any): Promise<void> => {
 
   const isForwardedMessage =
     packet.t == "MESSAGE_CREATE" && data.message_reference?.type == 1;
+  const isSoundMessage =
+    packet.t == "MESSAGE_CREATE" && data.hasOwnProperty("soundboard_sounds");
+  
   // For now, let's just block all non-staff forwarded messages. Permlevel 2 is mod, we can probably also allow helpers to forward.
   const permLevelToForwardMessage = 1;
 
-  if (isForwardedMessage) {
+  if (isForwardedMessage || isSoundMessage) {
     const channel = await client.channels.fetch(data.channel_id);
 
     if (!channel || !channel.isTextBased()) {
@@ -26,7 +29,11 @@ export default async (client: CustomClient, packet: any): Promise<void> => {
       return;
     }
 
-    const msg = await message.reply("You are not allowed to send polls in this channel.");
+    const text = isForwardedMessage
+      ? "You are not allowed to forward messages to this channel."
+      : "You are not allowed to send soundboard emojis in this channel.";
+    
+    const msg = await message.reply(text);
     await message.delete();
 
     setTimeout(async () => {


### PR DESCRIPTION
Blocks soundboard emojis in text channels from everyone below helper.

Tested this with Bagels in my bot testing server and it seems to work fine.