### PR TITLE
Fix automod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dani-server-utils",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "The Dani Discord (discord.gg/danii) server bot!",
   "main": "src/client.ts",
   "scripts": {

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -7,7 +7,6 @@ import {
   ContainerBuilder,
   EmbedBuilder,
   GuildChannel,
-  GuildNSFWLevel,
   MediaGalleryBuilder,
   Message,
   MessageFlags,
@@ -35,9 +34,15 @@ export default class MessageCreate extends EventLoader {
   }
 
   override async run(message: Message) {
-    if (message.type === MessageType.AutoModerationAction) {
-      if (message.content.match(/discord\.gg\/([a-zA-Z0-9]+)/g)) {
-        const matches = [...message.content.matchAll(/discord\.gg\/([a-zA-Z0-9]+)/g)];
+    if (message.type == MessageType.AutoModerationAction) {
+      let content = message.embeds[0].description;
+      if (!content) {
+        return this.client.logger.error(
+          "Internal error: data does not exist inside automod message;",
+        );
+      }
+      if (content.match(/discord\.gg\/([a-zA-Z0-9]+)/g)) {
+        const matches = [...content.matchAll(/discord\.gg\/([a-zA-Z0-9]+)/g)];
 
         matches.forEach(async (match) => {
           const code = match[1];


### PR DESCRIPTION
Automod originally was not logging these messages - because the message content is within a specialized "embed" (see [EmbedType#AutoModerationMessage](https://discord.js.org/docs/packages/discord.js/14.19.1/EmbedType:Enum#AutoModerationMessage))

This has been fixed by resolving from the first embed the bot sees (since there is only one) and resolves its description, where the content is at. (See attached img)
![image](https://github.com/user-attachments/assets/e7842ec0-f879-4c9f-beee-3c3303ca3a48)
