### PR TITLE
fix: repair leftover defer statement breaking LB

### DIFF
--- a/src/interactions/slashCommands/xp.ts
+++ b/src/interactions/slashCommands/xp.ts
@@ -158,7 +158,6 @@ export default class XpCommand extends CustomApplicationCommand {
       }
 
       case "leaderboard": {
-        await interaction.deferReply();
         const limit = Math.min(interaction.options.getNumber("limit") ?? 10, 25);
         const topUsers = await XpModel.find({ guildId: interaction.guildId })
           .select("userId expAmount")


### PR DESCRIPTION
Removes a leftover defer from before the command-scoped defer PR