### PR TITLE
Feat: String key caching and autocomplete.

### DIFF
--- a/lib/core/DsuClient.ts
+++ b/lib/core/DsuClient.ts
@@ -76,6 +76,12 @@ export class DsuClient extends Client {
   /** The loader used for slash command interactions. */
   public textCommandLoader: TextCommandLoader;
 
+  /**
+   * Cache of any string keys, key is and value is the keys they use
+   * For example, triggers would be <"trigger", ["each", "trigger", "here"]
+   */
+  public stringKeyCache: Collection<string, Set<string>>;
+
   /** Chain message storage */
   public channelMessages: Collection<
     string,
@@ -121,6 +127,7 @@ export class DsuClient extends Client {
     this.textCommands = new Collection();
     this.textCommandLoader = new TextCommandLoader(this);
 
+    this.stringKeyCache = new Collection();
     this.channelMessages = new Collection();
     this.dirtyCooldownHandler = new TimeoutHandler();
 

--- a/src/events/clientReady.ts
+++ b/src/events/clientReady.ts
@@ -5,6 +5,7 @@ import { EventLoader } from "../../lib/core/loader/EventLoader";
 import { ISettings } from "types/mongodb";
 import { SettingsModel } from "models/Settings";
 import { Times } from "types/index";
+import { TriggerModel } from "models/Trigger";
 import _ from "lodash";
 
 export default class ClientReady extends EventLoader {
@@ -65,6 +66,24 @@ export default class ClientReady extends EventLoader {
     }
   }
 
+  private async updateStringKeys(client: DsuClient, guildId: string) {
+    let settings = client.settings.get(guildId);
+
+    if (!settings) return;
+
+    let cache = client.stringKeyCache.get("triggers");
+
+    console.log("Settings ID:", settings, settings._id);
+
+    const dbTriggers = new Set(settings.triggers.map((t) => t.id));
+
+    if (cache) {
+      for (const t of dbTriggers) cache.add(t);
+    } else {
+      client.stringKeyCache.set("triggers", dbTriggers);
+    }
+  }
+
   override async run(client: DsuClient) {
     const updateSettings = async () => {
       if (client.isReady()) {
@@ -76,11 +95,17 @@ export default class ClientReady extends EventLoader {
       }
 
       await Promise.all(
-        Array.from(client.settings.keys()).map((guildId) =>
+        Array.from(client.settings.keys()).map((guildId) => {
           this.syncSettings(client, guildId).catch((e) =>
             client.logger.error("Sync failed for guild", { guildId, error: e }),
-          ),
-        ),
+          );
+          this.updateStringKeys(client, guildId).catch((e) =>
+            client.logger.error("Failed to update string keys for guild", {
+              guildId,
+              error: e,
+            }),
+          );
+        }),
       );
     };
 

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,13 +1,19 @@
-import { Collection, GuildMember, Interaction, InteractionType, MessageFlags } from "discord.js";
+import {
+  Collection,
+  GuildMember,
+  Interaction,
+  InteractionType,
+  MessageFlags,
+} from "discord.js";
 
+import { AutoPingUtility } from "../utilities/autoPing";
+import DefaultClientUtilities from "lib/util/defaultUtilities";
 import { DsuClient } from "lib/core/DsuClient";
 import { EventLoader } from "lib/core/loader/EventLoader";
-import DefaultClientUtilities from "lib/util/defaultUtilities";
+import { ISettings } from "types/mongodb";
+import { PermissionLevels } from "types/commands";
 import { SettingsModel } from "models/Settings";
 import { TriggerModel } from "models/Trigger";
-import { PermissionLevels } from "types/commands";
-import { ISettings } from "types/mongodb";
-import { AutoPingUtility } from "../utilities/autoPing";
 
 export default class InteractionCreate extends EventLoader {
   constructor(client: DsuClient) {
@@ -107,11 +113,10 @@ export default class InteractionCreate extends EventLoader {
       );
 
       if (interaction.isCommand()) {
-
         const command = this.client.applicationCommandLoader.fetchCommand(
           interaction.commandName,
         );
-        
+
         if (!command) {
           return this.client.logger.error(
             `Exception: Cannot find command to add cooldown (${interaction.commandName})`,
@@ -161,6 +166,14 @@ export default class InteractionCreate extends EventLoader {
         this.client.applicationCommandLoader.handle(interaction);
       } else if (interaction.isUserContextMenuCommand()) {
         this.client.applicationCommandLoader.handle(interaction);
+      } else if (interaction.isAutocomplete()) {
+        const command = this.client.applicationCommandLoader.fetchCommand(
+          interaction.commandName,
+        );
+        if (command && command.autoComplete) {
+          const focused = interaction.options.getFocused(true);
+          return command.autoComplete(interaction, focused);
+        }
       }
     } catch (error) {
       this.client.logger.error(`Failed to handle command ${interaction.id}: ${error}`);

--- a/src/interactions/slashCommands/trigger.ts
+++ b/src/interactions/slashCommands/trigger.ts
@@ -1,6 +1,8 @@
 import {
   ApplicationCommandOptionType,
   ApplicationCommandType,
+  AutocompleteFocusedOption,
+  AutocompleteInteraction,
   ChatInputCommandInteraction,
   ColorResolvable,
   EmbedBuilder,
@@ -110,6 +112,7 @@ export default class TriggerCommand extends CustomApplicationCommand {
             {
               name: "id",
               description: "The id of the trigger.",
+              autocomplete: true,
               type: ApplicationCommandOptionType.String,
               required: true,
             },
@@ -160,6 +163,7 @@ export default class TriggerCommand extends CustomApplicationCommand {
             {
               name: "id",
               description: "The id of the trigger.",
+              autocomplete: true,
               type: ApplicationCommandOptionType.String,
               required: true,
             },
@@ -196,11 +200,11 @@ export default class TriggerCommand extends CustomApplicationCommand {
           description: "Show a trigger without it having to be triggered.",
           type: ApplicationCommandOptionType.Subcommand,
           level: PermissionLevels.HELPER,
-
           options: [
             {
               name: "trigger_id",
               description: "The id of the trigger.",
+              autocomplete: true,
               type: ApplicationCommandOptionType.String,
               required: true,
             },
@@ -272,6 +276,14 @@ export default class TriggerCommand extends CustomApplicationCommand {
         ),
       );
 
+      const cache = this.client.stringKeyCache.get("triggers");
+
+      if (!cache) {
+        this.client.stringKeyCache.set("triggers", new Set([trigger.id]));
+      } else {
+        cache.add(trigger.id);
+      }
+
       await interaction.reply({
         embeds: [
           new EmbedBuilder()
@@ -298,6 +310,14 @@ export default class TriggerCommand extends CustomApplicationCommand {
             guildId: interaction.guildId,
             triggerId: `trigger-${id}`,
           });
+        }
+
+        const cache = this.client.stringKeyCache.get("triggers");
+
+        if (!cache) {
+          this.client.stringKeyCache.set("triggers", new Set());
+        } else {
+          cache.delete(id);
         }
 
         await interaction.reply({
@@ -537,5 +557,28 @@ export default class TriggerCommand extends CustomApplicationCommand {
         interaction.reply(trigger.message.content);
       }
     }
+  }
+
+  public async autoComplete(
+    interaction: AutocompleteInteraction,
+    option: AutocompleteFocusedOption,
+  ) {
+    const query = option.value.toLowerCase();
+
+    const cache = this.client.stringKeyCache.get("triggers");
+
+    if (!cache) {
+      return;
+    }
+
+    const filtered = cache.values().filter((word) => word.includes(query));
+
+    console.log(
+      "Filtered result: ",
+      filtered.map((trigger) => ({ name: trigger, value: trigger })),
+    );
+    await interaction.respond([
+      ...filtered.map((trigger) => ({ name: trigger, value: trigger })),
+    ]);
   }
 }


### PR DESCRIPTION
Adds support for autocomplete, a `client.stringKeyCache` property, and now includes autocomplete on any `trigger_id` check for triggers (i.e. `get`, `remove`, and `display`)

The stringKeyCache is a `Collection<string, Set<string>>` where its key is the command it falls under (ex: `triggers`), and its value is a Set of strings, using a set instead of map for unique values. 

<img width="1267" height="241" alt="image" src="https://github.com/user-attachments/assets/df8f9bb4-7544-4e1c-8ac2-7314d281f131" />
<img width="1260" height="241" alt="image" src="https://github.com/user-attachments/assets/98a5e7ec-fa73-4c25-9b04-8e07f0692ace" />

Currently this really only matters for triggers, since theyre the only command set to use string keys, but it's at least here now to have. 

The cache is currently updated in 3 places: 
- Populated in the `updateStringKeys` function in `clientReady`.
- Adding a trigger adds it to the cache.
- Removing a trigger removes it from the cache.

Autocomplete is added via the `autoComplete` method on a slash command, see the example now included on `trigger.ts` or the function in `ApplicationCommand.ts` 